### PR TITLE
Minor fixes for the chunked problem

### DIFF
--- a/nglpy_cuda/Graph.py
+++ b/nglpy_cuda/Graph.py
@@ -179,7 +179,7 @@ class Graph(object):
         # should give the user something to process in the meantime, so
         # don't remove these lines and make sure to return in the main
         # populate before the same process is done again.
-        self.push_edges(edges[:count], distances[:count])
+        self.push_edges(edges[:count], distances[:count], indices[:count])
 
     def populate_whole(self):
         count = self.X.shape[0]
@@ -214,8 +214,11 @@ class Graph(object):
                 self.populate_whole()
         self.push_edges(self.edges, self.distances)
 
-    def push_edges(self, edges, distances):
-        valid_edges = ngl.get_edge_list(edges, distances)
+    def push_edges(self, edges, distances, indices=None):
+        if indices != None:
+            valid_edges = ngl.get_edge_list(edges, distances, indices)
+        else:
+            valid_edges = ngl.get_edge_list(edges, distances)
         for edge in valid_edges:
             self.edge_list.put(edge)
 

--- a/nglpy_cuda/Graph.py
+++ b/nglpy_cuda/Graph.py
@@ -219,7 +219,7 @@ class Graph(object):
         self.push_edges(self.edges, self.distances)
 
     def push_edges(self, edges, distances, indices=None):
-        if indices != None:
+        if indices is not None:
             valid_edges = ngl.get_edge_list(edges, distances, indices)
         else:
             valid_edges = ngl.get_edge_list(edges, distances)

--- a/src/ngl_cuda.cu
+++ b/src/ngl_cuda.cu
@@ -781,7 +781,14 @@ namespace nglcu {
             int *map_d;
             int i;
 
-            cudaMallocManaged(&map_d, N*sizeof(int));
+	    int max_index = 0;
+	    for(i = 0; i < N; i++) {
+	        if(indices[i] > max_index) {
+		    max_index = indices[i];
+		}
+	    }
+
+            cudaMallocManaged(&map_d, max_index*sizeof(int));
             for(i = 0; i < N; i++) {
                 map_d[indices[i]] = i;
             }

--- a/src/ngl_cuda.cu
+++ b/src/ngl_cuda.cu
@@ -781,12 +781,12 @@ namespace nglcu {
             int *map_d;
             int i;
 
-	    int max_index = 0;
-	    for(i = 0; i < N; i++) {
-	        if(indices[i] > max_index) {
-		        max_index = indices[i];
-		    }
-	    }
+            int max_index = 0;
+            for(i = 0; i < N; i++) {
+                if(indices[i] > max_index) {
+                    max_index = indices[i];
+                }
+            }
 
             cudaMallocManaged(&map_d, max_index*sizeof(int));
             for(i = 0; i < N; i++) {

--- a/src/ngl_cuda.cu
+++ b/src/ngl_cuda.cu
@@ -784,8 +784,8 @@ namespace nglcu {
 	    int max_index = 0;
 	    for(i = 0; i < N; i++) {
 	        if(indices[i] > max_index) {
-		    max_index = indices[i];
-		}
+		        max_index = indices[i];
+		    }
 	    }
 
             cudaMallocManaged(&map_d, max_index*sizeof(int));


### PR DESCRIPTION
There are currently two bugs in the chunked problem that are addressed with this PR:
* Using correct offset when pushing edges onto the queue for consumption by adding the indices as a parameter to the new `push_edges` method.
* Using the maximum index in the working set as the maximum size of the lookup array for mapping indices to their new positions in the associated arrays.